### PR TITLE
Tests: Pin Products.TextIndexNG3 and dependencies to fix test build.

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -10,3 +10,7 @@ versions = versions
 setuptools = 0.6c11
 zc.buildout = 1.7.1
 zc.recipe.egg = 1.3.2
+
+Products.TextIndexNG3 = 3.4.14
+zopyx.txng3.core = 3.6.2
+zopyx.txng3.ext = <3.4.99999


### PR DESCRIPTION
Pin Products.TextIndexNG3 and its dependencies to fix [test build](https://ci.4teamwork.ch/builds/86409/tasks/125687#bottom).

The most recent version of`zopyx.txng3.core` now constrains `zopyx.txng3.ext`: 
https://github.com/zopyx/zopyx.txng3.core/blob/122fb899a13faec8c16f3f4d09687bb583a3f745/setup.py#L38